### PR TITLE
Switch to alpine-based python:2.7 base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,5 @@
-FROM python:2.7
+FROM python:2.7-alpine
 
-RUN apt-get update && apt-get install -y python-pip
 RUN pip install boto3
 
 COPY check.py /opt/resource/check


### PR DESCRIPTION
The resource image is unnecessarily large - 413 MB!
Switching to a lighter base image will make it much smaller.